### PR TITLE
Add a year filter and download ready page

### DIFF
--- a/app/views/dataset/local/spending/filter/download.html
+++ b/app/views/dataset/local/spending/filter/download.html
@@ -1,0 +1,30 @@
+{% extends "layout.html" %}
+
+
+{% block page_title %}
+  Dataset - data.gov.uk
+{% endblock %}
+
+{% block content %}
+
+<main id="content" class="local-authority-choice" role="main">
+
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <p class="heading-first">Local Authorities datasets collection</p>
+      <h1 class="heading-large">Spending over £500</h1>
+    </div>
+  </div>
+
+  <div class="govuk-box-highlight">
+    <h2 class="heading-xlarge">
+      Your download is ready
+    </h2>
+    <p class="font-large">
+      <a href="/">Download now</a>
+    </p>
+  </div>
+
+</main>
+
+{% endblock %}

--- a/app/views/dataset/local/spending/filter/year.html
+++ b/app/views/dataset/local/spending/filter/year.html
@@ -13,24 +13,24 @@
     <div class="column-two-thirds">
       <p class="heading-first">Local Authorities datasets collection</p>
       <h1 class="heading-large">Spending over £500</h1>
-      <p class="lede">Select Local Authorities</p>
+      <p class="lede">Select years</p>
     </div>
   </div>
 
   <div class="grid-row">
       <form id="select-LA" action="" method="GET" class="column-two-thirds">
         <fieldset>
-          {% for organisation in data.organisations %}
+          {% for year in [2017, 2016, 2015, 2014, 2013, 2012, 2011, 2010] %}
           <div class="multiple-choice">
-            <input id="checkbox-{{ organisation.name }}"
-                   name="LA"
+            <input id="checkbox-{{ year }}"
+                   name="year"
                    type="checkbox"
-                   value="{{ organisation.name }}">
-            <label for="checkbox-{{ organisation.name }}">{{ organisation.title }}</label>
+                   value="{{ year }}">
+            <label for="checkbox-{{ year }}">{{ year }}</label>
           </div>
           {% endfor %}
           <div class="form-group">
-            <a href="year" class="button">Next</a>
+            <a class="button" href="download">Download</a>
           </div>
         </fieldset>
       </form>


### PR DESCRIPTION
Following on from the organisations filter, add a years filter and
following that, a Your download is ready page.

Now when looking at an aggregated local dataset, and choose to download 'part' of the dataset you can filters whichever organisations and years are available before being given a link to the filtered dataset for download.

Fixes #11 